### PR TITLE
Remove redundant categories with lincRNA genes

### DIFF
--- a/cwas/core/configuration/settings.py
+++ b/cwas/core/configuration/settings.py
@@ -58,6 +58,7 @@ _redundant_domain_pairs = {
         ("Any", "MissenseRegion"),
         ("Any", "SilentRegion"),
         ("Any", "lincRnaRegion"),
+        ("lincRNA", "Any")
     },
 }
 


### PR DESCRIPTION
Categories with lincRNA genes are counted as the same in 'Any' region and 'NoncodingRegion'.

We will remove redundant categories (gencode=Any & gene_list=lincRNA).