### PR TITLE
Parsing annotated VCF without missing annotations

### DIFF
--- a/cwas/core/categorization/parser.py
+++ b/cwas/core/categorization/parser.py
@@ -131,7 +131,7 @@ def _parse_annot_column(
     """ Parse the annotation integer in the ANNOT column and make a
     pd.DataFrame object
     """
-    annot_ints = annot_column.values.astype(float)
+    annot_ints = np.array([int(x) for x in annot_column])
     annot_field_cnt = len(annot_field_names)
     annot_records = list(
         map(


### PR DESCRIPTION
- Update parser.py
Before, parsing annotated VCF used float type to parse annotated integer of each variant. However, with big numbers, float type cause confusion in calculation so we changed float type to integer type.